### PR TITLE
Moved the WX 7100 to the correct section in amd-gpu.md

### DIFF
--- a/modern-gpus/amd-gpu.md
+++ b/modern-gpus/amd-gpu.md
@@ -71,7 +71,6 @@ Radeon Pro:
 
 * Vega Frontier Edition
 * Radeon Pro WX 9100
-* Radeon Pro WX 7100
 
 Needed kexts:
 
@@ -107,6 +106,7 @@ Supported cards:
 
 Radeon Pro:
 
+* WX 7100
 * WX 5100
 * WX 4100
 * E9550


### PR DESCRIPTION
**Update amd-gpu.md**
Radeon Pro WX 7100 is a Polaris-based GPU (Polaris 10 XT GL), not the Vega (its specs are on par with the RX 480/580)