### PR TITLE
Remove FakeID needed for 380 & 370

### DIFF
--- a/modern-gpus/amd-gpu.md
+++ b/modern-gpus/amd-gpu.md
@@ -132,9 +132,9 @@ Supported cards:
 * R9 290X/390X
 * R9 290/390(FakeID needed)
 * R9 280x/380x (Hit or miss)
-* R9 280/380(FakeID needed)
+* R9 280/380
 * R9 270X/370X
-* R7 270/370(FakeID needed)
+* R7 270/370
 * R7 265
 * R7 260x/360x
 * R9 260/360(FakeID may be required depending on model)


### PR DESCRIPTION
https://www.reddit.com/r/hackintosh/comments/9gn91k/all_supported_amd_gpus_from_macos_mojave_beta_11/

Looks like the R9 380, R9 280, R7 370, R7 270 are all supported by AMD9000Controller.kext and AMD7000Controller.kext.

My R9 380 2GB works on Catalina with DRM, Metal, and full graphics acceleration support: https://imgur.com/a/a48QWc7