### PR TITLE
Fix XTX device ID

### DIFF
--- a/modern-gpus/amd-gpu.md
+++ b/modern-gpus/amd-gpu.md
@@ -30,7 +30,7 @@ Supported Cards:
 * RX 6800
 * RX 6800 XT
 * RX 6900 XT
-  * The XTXH variant (Device ID: `0x73AF`) is supported with WhateverGreen 1.5.2 and spoofing `device-id` to `0x73AE`.
+  * The XTXH variant (Device ID: `0x73AF`) is supported with WhateverGreen 1.5.2 and spoofing `device-id` to `0x73BF`.
 
 Note: Some Navi 21 cards currently require the boot argument `agdpmod=pikera` to get a display out.
 


### PR DESCRIPTION
The guide lists `73AE` as the device ID for the XTX variant of the 6900 XT, but it's actually `73BF` according to the PCI ID repository and I've seen System Information screenshots from people with XTX cards.

https://pci-ids.ucw.cz/read/PC/1002/73bf