### PR TITLE
Update the documentation to say that RDNA 3 is not yet supported

### DIFF
--- a/modern-gpus/amd-gpu.md
+++ b/modern-gpus/amd-gpu.md
@@ -259,7 +259,7 @@ Extras:
 
 #### Highest Supported OS: None
 
-While Navi 21 and Navi 23 are supported, but Navi 22, Navi 24 and Navi 3X are not at the time of writing.
+While Navi 21 and Navi 23 are supported, Navi 22, Navi 24 and Navi 3X based graphic cards are not at the time of writing.
 
 Unsupported Cards:
 

--- a/modern-gpus/amd-gpu.md
+++ b/modern-gpus/amd-gpu.md
@@ -259,7 +259,7 @@ Extras:
 
 #### Highest Supported OS: None
 
-While Navi 21 and Navi 23 are supported, Navi 22 and Navi 3X are not at the time of writing.
+While Navi 21 and Navi 23 are supported, but Navi 22, Navi 24 and Navi 3X are not at the time of writing.
 
 Unsupported Cards:
 
@@ -267,6 +267,8 @@ Unsupported Cards:
 * RX 7900 XT
 * RX 6750 XT
 * RX 6700 XT
+* RX 6500 XT
+* RX 6400
 
 ### **Lexa Series**
 

--- a/modern-gpus/amd-gpu.md
+++ b/modern-gpus/amd-gpu.md
@@ -255,14 +255,17 @@ Extras:
 
 ## Unsupported AMD GPUs
 
-### **Navi 2X**
+### **Navi 2X and Navi 3X**
 
 #### Highest Supported OS: None
 
-While Navi 21 and Navi 23 are supported, the other cores are not at the time of writing.
+While Navi 21 and Navi 23 are supported, Navi 22 and Navi 3X are not at the time of writing.
 
 Unsupported Cards:
 
+* RX 7900 XTX
+* RX 7900 XT
+* RX 6750 XT
 * RX 6700 XT
 
 ### **Lexa Series**


### PR DESCRIPTION
This PR will update the list of AMD GPUs that are not yet supported. Primarily, the new Navi 3/RDNA 3 cards.