### PR TITLE
Added agdpmod=pikera to Navi 23

### DIFF
--- a/modern-gpus/amd-gpu.md
+++ b/modern-gpus/amd-gpu.md
@@ -44,13 +44,6 @@ Needed kexts:
 * [Lilu.kext](https://github.com/acidanthera/Lilu/releases)
 * [WhateverGreen.kext](https://github.com/acidanthera/WhateverGreen/releases)
 
-<details>
-  <summary>Navi 21 and 23 series without WhateverGreen</summary>
-  
- On macOS Ventura, by setting iMacPro1,1 or MacPro7,1 SMBIOS you can use Navi 21 and 23 cards without WhateverGreen or `agdpmod=pikera` in boot args.
-  
-</details>
-
 ### **Navi 10 Series**
 
 #### Highest Supported OS: Current/Ventura (13)
@@ -74,7 +67,7 @@ Radeon Pro:
 * Radeon Pro W5500
 * Radeon Pro W5700
 
-Note: Most Navi 10 cards currently require the boot argument `agdpmod=pikera` to get proper display out.
+Note: Most Navi 10 and 14 cards currently require the boot argument `agdpmod=pikera` to get proper display out.
 
 Needed kexts:
 
@@ -139,7 +132,7 @@ Needed kexts:
 
 Regarding Polaris, basically every model of card is supported as long as it’s running either a Polaris or Baffin core. Lower end cards like the RX 550 may run a Lexa core, meaning no support in macOS.
 
-The only brands **you should avoid with the Polaris series would be PowerColor, HIS and VisionTek** as many users have had bootloader and macOS boot issues. Other users have found fixes/workarounds, though nothing consistent. This seems to be caused by having an odd VBIOS that doesn't communicate well with macOS and the only real solution is flashing another VBIOS, which is not ideal for most users.
+The only brands **you should avoid with the Polaris series would be XFX (460/560 models), PowerColor, HIS and VisionTek** as many users have had bootloader and macOS boot issues. Other users have found fixes/workarounds, though nothing consistent. This seems to be caused by having an odd VBIOS that doesn't communicate well with macOS and the only real solution is flashing another VBIOS, which is not ideal for most users.
 
 Supported cards:
 

--- a/modern-gpus/amd-gpu.md
+++ b/modern-gpus/amd-gpu.md
@@ -15,6 +15,8 @@ Supported Cards:
 * RX 6600
 * RX 6600 XT
 
+Note: Most Navi 23 cards currently require the boot argument `agdpmod=pikera` to get a display out.
+
 Needed kexts:
 
 * [Lilu.kext](https://github.com/acidanthera/Lilu/releases)
@@ -35,12 +37,19 @@ Supported Cards:
 * RX 6900 XT
   * The XTXH variant (Device ID: `0x73AF`) is supported with WhateverGreen 1.5.2 and spoofing `device-id` to `0x73BF`.
 
-Note: Some Navi 21 cards currently require the boot argument `agdpmod=pikera` to get a display out.
+Note: Most Navi 21 cards currently require the boot argument `agdpmod=pikera` to get a display out.
 
 Needed kexts:
 
 * [Lilu.kext](https://github.com/acidanthera/Lilu/releases)
 * [WhateverGreen.kext](https://github.com/acidanthera/WhateverGreen/releases)
+
+<details>
+  <summary>Navi 21 and 23 series without WhateverGreen</summary>
+  
+ On macOS Ventura, by setting iMacPro1,1 or MacPro7,1 SMBIOS you can use Navi 21 and 23 cards without WhateverGreen or `agdpmod=pikera` in boot args.
+  
+</details>
 
 ### **Navi 10 Series**
 
@@ -65,7 +74,7 @@ Radeon Pro:
 * Radeon Pro W5500
 * Radeon Pro W5700
 
-Note: Most Navi cards currently require the boot argument `agdpmod=pikera` to get proper display out.
+Note: Most Navi 10 cards currently require the boot argument `agdpmod=pikera` to get proper display out.
 
 Needed kexts:
 
@@ -130,7 +139,7 @@ Needed kexts:
 
 Regarding Polaris, basically every model of card is supported as long as it’s running either a Polaris or Baffin core. Lower end cards like the RX 550 may run a Lexa core, meaning no support in macOS.
 
-The only brands **you should avoid with the Polaris series would be XFX, PowerColour, HIS and VisionTek** as many users have had bootloader and macOS boot issues. Other users have found fixes/workarounds, though nothing consistent. This seems to be caused by having an odd VBIOS that doesn't communicate well with macOS and the only real solution is flashing another VBIOS, which is not ideal for most users.
+The only brands **you should avoid with the Polaris series would be PowerColor, HIS and VisionTek** as many users have had bootloader and macOS boot issues. Other users have found fixes/workarounds, though nothing consistent. This seems to be caused by having an odd VBIOS that doesn't communicate well with macOS and the only real solution is flashing another VBIOS, which is not ideal for most users.
 
 Supported cards:
 

--- a/modern-gpus/amd-gpu.md
+++ b/modern-gpus/amd-gpu.md
@@ -28,7 +28,7 @@ Needed kexts:
 
 #### Initial Supported OS: Big Sur (11.4)
 
-As of 11.4, Apple has added Navi 21 support!
+As of 11.4, Apple has added Navi 21 support.
 
 Supported Cards:
 
@@ -50,7 +50,7 @@ Needed kexts:
 
 #### Initial Supported OS: Catalina (10.15.1)
 
-Currently, as of 10.15.1, Apple has finally added RDNA and Navi support!
+Currently, as of 10.15.1, Apple has finally added RDNA and Navi support.
 
 Supported Cards:
 


### PR DESCRIPTION
- Added `agdpmod=pikera` to Navi 23 since many if not all Navi 21 and 23 cards require this boot arg to avoid black screen on Desktop.
<s>- Added a spoiler to inform that in Ventura it is possible to use Navi 21 and 23 cards without WhateverGreen and the boot arg by setting the SMBIOS model to iMacPro1,1 or MacPro7,1.
- Removed XFX from the list of brands to avoid on Polaris cards, many users are using them with no issues from Catalina to Ventura.</s>
- Changed PowerColour to PowerColor (typo)
- Added 14 to Navi 10 boot arg comment (@1Revenger1).