### PR TITLE
Update legacy-amd.md

### DIFF
--- a/legacy-gpus/legacy-amd.md
+++ b/legacy-gpus/legacy-amd.md
@@ -33,6 +33,7 @@ Also to note: `InjectATI` may be required for these GPUs.
 
 * HD 5450
 * HD 5470
+* HD 5550 (spoof to `68d9` if needed, spoofed card will also require [no-gfx-spoof](https://github.com/acidanthera/bugtracker/issues/1743) property
 * HD 5570
 * HD 5630
 * HD 5670


### PR DESCRIPTION
Note that the HD 5550 is also supported.

My own card has a device ID of `68da` which is not present in the macOS drivers and requires a spoof to `68d9`, with which it works perfectly fine. Besides HS, I have tested it in Monterey with OCLP and a mostly passing result.